### PR TITLE
npm install in libs before build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ build-frontend:
 	fi
 
 up:
+	@cd backend/libs/jwt_authenticator && npm install
 	@echo "$(YELLOW)Building docker images...$(RESET)"
 	@docker compose -f $(DOCKER_COMPOSE_FILE) up -d
 	@echo "$(GREEN)Docker images built.$(RESET)"
@@ -55,6 +56,7 @@ down:
 	@echo "$(GREEN)Docker containers stopped.$(RESET)"
 
 basic: ssl_cert build-frontend
+	@cd backend/libs/jwt_authenticator && npm install
 	@echo "$(YELLOW)Building docker images...$(RESET)"
 	@docker-compose -f $(DOCKER_COMPOSE_FILE) up -d nginx file_service user_service  game_service googlesignin
 	@echo "$(GREEN)Docker images built.$(RESET)"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,8 +90,6 @@ services:
 
   logstash:
     depends_on:
-      setup:
-        condition: service_completed_successfully
       es01:
         condition: service_healthy
     image: docker.elastic.co/logstash/logstash:${STACK_VERSION}


### PR DESCRIPTION
This pull request updates the `Makefile` to ensure dependencies for the `jwt_authenticator` library are installed during relevant build and setup commands. The changes improve automation and consistency in the build process.

Dependency installation updates:

* Added a step to run `npm install` in the `backend/libs/jwt_authenticator` directory as part of the `up` target to ensure required dependencies are installed before building Docker images. (`[MakefileR47](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R47)`)
* Added the same `npm install` step for the `basic` target to ensure dependencies are installed when building specific services. (`[MakefileR59](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R59)`)